### PR TITLE
Возможность запуска утилиты MetadataBrowser из главного окна утилиты

### DIFF
--- a/RXInstanceManager/AppHandlers.cs
+++ b/RXInstanceManager/AppHandlers.cs
@@ -236,7 +236,7 @@ namespace RXInstanceManager
       LaunchProcess(fileName, null, asAdmin, false);
     }
 
-    public static void LaunchProcess(string fileName, string args, bool asAdmin, bool waitForExit)
+    public static void LaunchProcess(string fileName, string args, bool asAdmin, bool waitForExit, bool isHiddenCommandLine = false)
     {
       using (var process = new Process())
       {
@@ -252,6 +252,14 @@ namespace RXInstanceManager
 
         if (asAdmin)
           process.StartInfo.Verb = "runas";
+
+        if (isHiddenCommandLine)
+        {
+          process.StartInfo.CreateNoWindow = true;
+          process.StartInfo.UseShellExecute = false;
+          process.StartInfo.RedirectStandardOutput = true;
+          process.StartInfo.RedirectStandardError = true;
+        }
 
         try
         {

--- a/RXInstanceManager/Entities/Models/Config.cs
+++ b/RXInstanceManager/Entities/Models/Config.cs
@@ -27,6 +27,10 @@ namespace RXInstanceManager
     public string LogViewer { get; set; }
     internal bool LogViewerExists { get; set; }
 
+    public string MetadataBrowser { get; set; }
+
+    internal bool MetadataBrowserExists { get; set; }
+
     public bool NeedCheckAfterSet { get; set; }
 
     public ContextMenuClass ContextMenu { get; set; }

--- a/RXInstanceManager/MainWindow.xaml
+++ b/RXInstanceManager/MainWindow.xaml
@@ -42,6 +42,7 @@
         <Button x:Name="ButtonDDSStart" Content="Development Studio" Style="{DynamicResource RecordActionButton}" Background="GreenYellow" Click="ButtonDDSStart_Click" />
         <Button x:Name="ButtonRXStart" Content="Веб-клиент" Style="{DynamicResource RecordActionButton}" Background="Violet" Click="ButtonRXStart_Click" />
         <Button x:Name="ButtonLogViewer" Content="Directum LogViewer" Style="{DynamicResource RecordActionButton}" Background="Gray" Click="RunDirectumLogViewer_Click" />
+        <Button x:Name="ButtonMetadataBrowser" Content="Metadata Browser" Style="{DynamicResource RecordActionButton}" Background="Yellow" Click="RunMetadataBrowser_Click" />
         <Button x:Name="ButtonSourcesFolder" Content="Папка исходников" Style="{DynamicResource RecordActionButton}" Background="#FFDCA3FF" Click="ButtonSourcesFolder_Click" />
       </StackPanel>
       <DataGrid x:Name="GridInstances" AutoGenerateColumns="False" Style="{DynamicResource DataGridStyle}" Grid.Row="1" SelectionChanged="GridInstances_SelectionChanged" >

--- a/RXInstanceManager/MainWindow.xaml.cs
+++ b/RXInstanceManager/MainWindow.xaml.cs
@@ -443,6 +443,21 @@ namespace RXInstanceManager
         System.Windows.MessageBox.Show($"Папка {_instance.LogFolder} не существует.", "", System.Windows.MessageBoxButton.OK, System.Windows.MessageBoxImage.Error);
     }
 
+    private void RunMetadataBrowser_Click(object sender, RoutedEventArgs e)
+    {
+      if (_instance == null)
+        return;
+
+      try
+      {
+        Task.Run(() => AppHandlers.LaunchProcess(AppHelper.GetDoPath(_instance.InstancePath), "map run_metadata_browser", true, false, true));
+      }
+      catch (Exception ex)
+      {
+        AppHandlers.ErrorHandler(_instance, ex);
+      }
+    }
+
     private void ButtonSourcesFolder_Click(object sender, RoutedEventArgs e)
     {
       if (Directory.Exists(_instance.WorkingRepositoryName))

--- a/RXInstanceManager/MainWindow.xaml.cs
+++ b/RXInstanceManager/MainWindow.xaml.cs
@@ -448,9 +448,10 @@ namespace RXInstanceManager
       if (_instance == null)
         return;
 
+      if (File.Exists(_configRxInstMan.MetadataBrowser))
       try
       {
-        Task.Run(() => AppHandlers.LaunchProcess(AppHelper.GetDoPath(_instance.InstancePath), "map run_metadata_browser", true, false, true));
+        Task.Run(() => AppHandlers.LaunchProcess(AppHelper.GetDoPath(_instance.InstancePath), "map run_metadata_browser " + _configRxInstMan.MetadataBrowser, true, false, true));
       }
       catch (Exception ex)
       {

--- a/RXInstanceManager/MainWindowHandlers.cs
+++ b/RXInstanceManager/MainWindowHandlers.cs
@@ -42,6 +42,7 @@ namespace RXInstanceManager
 
         var config = new Config();
         config.LogViewer = "";
+        config.MetadataBrowser = "";
         config.NeedCheckAfterSet = false;
         config.ContextMenu = contextMenu;
         var serializer = new YamlDotNet.Serialization.SerializerBuilder()
@@ -66,6 +67,20 @@ namespace RXInstanceManager
           _configRxInstMan.LogViewerExists = File.Exists(_configRxInstMan.LogViewer);
           if (!_configRxInstMan.LogViewerExists)
             AppHandlers.logger.Error(string.Format("Файл LogViewer {0} не найден", _configRxInstMan.LogViewer));
+          try
+          {
+            _configRxInstMan.MetadataBrowser = ymlData.metadataBrowser;
+          }
+          catch (Exception e)
+          {
+            if (Environment.UserDomainName == "NT_WORK")
+              _configRxInstMan.MetadataBrowser = "\\\\orpihost\\MetadataBrowser\\MetadataBrowser.exe";
+            else
+              _configRxInstMan.MetadataBrowser = "";
+          }
+          _configRxInstMan.MetadataBrowserExists = File.Exists(_configRxInstMan.MetadataBrowser);
+          if (!_configRxInstMan.MetadataBrowserExists)
+            AppHandlers.logger.Error(string.Format("Файл MetadataBrowser {0} не найден", _configRxInstMan.MetadataBrowser));
           _configRxInstMan.NeedCheckAfterSet = (ymlData.needCheckAfterSet == "true") ? true : false;
 
           Func<string, bool> getContext = (contextMenuItem) => !ymlData.contextMenu.ContainsKey(contextMenuItem) || ymlData.contextMenu[contextMenuItem] == "true" ? true : false;
@@ -198,6 +213,10 @@ namespace RXInstanceManager
             ButtonLogViewer.Visibility = Visibility.Visible;
           else
             ButtonLogViewer.Visibility = Visibility.Collapsed;
+          if (_configRxInstMan.MetadataBrowserExists)
+            ButtonMetadataBrowser.Visibility = Visibility.Visible;
+          else
+            ButtonMetadataBrowser.Visibility = Visibility.Collapsed;
           ButtonSourcesFolder.Visibility = Visibility.Visible;
           break;
         case Constants.InstanceStatus.Working:
@@ -209,6 +228,10 @@ namespace RXInstanceManager
             ButtonLogViewer.Visibility = Visibility.Visible;
           else
             ButtonLogViewer.Visibility = Visibility.Collapsed;
+          if (_configRxInstMan.MetadataBrowserExists)
+            ButtonMetadataBrowser.Visibility = Visibility.Visible;
+          else
+            ButtonMetadataBrowser.Visibility = Visibility.Collapsed;
           ButtonSourcesFolder.Visibility = Visibility.Visible;
           break;
       }


### PR DESCRIPTION
На главное окно утилиты добавлена кнопка для запуска MetadataBrowser.
При нажатии на кнопку выполняется команда запуска утилиты через плагин к DL.